### PR TITLE
Add GPL snippet for license checker test

### DIFF
--- a/src/gpl-snippet-test.c
+++ b/src/gpl-snippet-test.c
@@ -1,0 +1,63 @@
+/* xmalloc.c -- malloc with out of memory checking
+   Copyright (C) 1990-1996, 2000-2003 Free Software Foundation, Inc.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2, or (at your option)
+   any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software Foundation,
+   Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
+
+#include <sys/types.h>
+
+#if STDC_HEADERS
+# include <stdlib.h>
+#else
+void *calloc ();
+void *malloc ();
+void *realloc ();
+void free ();
+#endif
+
+#include "error.h"
+
+#ifndef EXIT_FAILURE
+# define EXIT_FAILURE 1
+#endif
+
+/* Exit value when the requested amount of memory is not available.
+   The caller may set it to some other value.  */
+int xmalloc_exit_failure = EXIT_FAILURE;
+
+#if __STDC__ && (HAVE_VPRINTF || HAVE_DOPRNT)
+void error (int, int, const char *, ...);
+#else
+void error ();
+#endif
+
+static void
+fixup_null_alloc (size_t n)
+{
+  if (n == 0)
+    error (xmalloc_exit_failure, 0, "memory exhausted");
+}
+
+/* Allocate N bytes of memory dynamically, with error checking.  */
+
+void *
+xmalloc (size_t n)
+{
+  void *p;
+
+  p = malloc (n);
+  if (p == 0)
+    fixup_null_alloc (n);
+  return p;
+}


### PR DESCRIPTION
## Summary
- Adds `src/gpl-snippet-test.c`, a copy of GNU `xmalloc.c` (GPL v2+, FSF copyright) under `src/`
- Purpose: verify the open-source license snippet checker flags GPL'd code on merge

## Test plan
- [ ] Snippet checker runs on the PR
- [ ] Checker reports the GPL header / FSF copyright as a license violation